### PR TITLE
Use new null part syntax for ffmpeg remote part

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,8 +15,8 @@ parts:
   youtube-dl:
     plugin: python
     source: .
-    after:
-      - ffmpeg
+
+  ffmpeg:
 
 apps:
   youtube-dl:


### PR DESCRIPTION
Since Snapcraft 2.43 it's now possible to specify building a part
without listing it in an existing part's `after` clause, which may cause
the depending part been unnecessarily clean due to the dependency.

Refer https://github.com/snapcore/snapcraft/pull/2153 for more info
about the syntax.

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>
