### PR TITLE
Fix CJKV character missing from resulting filename

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,9 +18,11 @@ parts:
     after:
       - ffmpeg
 
+  locales-launch:
+
 apps:
   youtube-dl:
-    command: youtube-dl
+    command: locales-launch youtube-dl
     plugs:
       - home
       - network


### PR DESCRIPTION
When downloading a video with a CJKV filename(like _video_url_) the
following warning message occurs:

```
WARNING: Assuming --restrict-filenames since file system encoding cannot
encode all characters. Set the LC_ALL environment variable to fix this
```

and the resulting filename's CJKV characters are stripped.

This is due to the missing glibc locales data, this patch fixes the
issue by incorporating the locales-launch remote part, which generates
the required data at runtime.

Refer [The `locales-launch` remote part - doc -
snapcraft.io](https://forum.snapcraft.io/t/the-locales-launch-remote-part/8729)
for more info about this remote part.

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>
