### PR TITLE
Support Unicode filenames without using locales-launch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,12 +18,13 @@ parts:
 
   ffmpeg:
 
-  locales-launch:
-
 apps:
   youtube-dl:
-    command: locales-launch youtube-dl
+    command: youtube-dl
     plugs:
       - home
       - network
       - removable-media
+    environment:
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8


### PR DESCRIPTION
It turns out that user glibc locale compilation isn't necessary[1] for
Unicode filename compatibility if we set the environment to directly
use the `C.UTF-8` locale shipped in the core snap.

[1] https://forum.snapcraft.io/t/lack-of-compiled-locales-breaks-gettext-based-localisation/3758/20

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>