### PR TITLE
Add 'personal-files' and 'system-files' interface to the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,14 @@ architectures:
   - build-on: armhf
   - build-on: arm64
 
+plugs:
+  dot-config-youtube-dl:
+    interface: personal-files
+    read: [$HOME/.config/youtube-dl/config]
+  config-youtube-dl:
+    interface: system-files
+    read: [/etc/youtube-dl.conf]
+
 apps:
   youtube-dl:
     command: youtube-dl
@@ -23,7 +31,10 @@ apps:
       - network
       - opengl
       - removable-media
+      - dot-config-youtube-dl
+      - config-youtube-dl
     environment:
+      HOME: $SNAP_REAL_HOME
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       LD_LIBRARY_PATH: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio"


### PR DESCRIPTION
`youtube-dl` may load `/etc/youtube-dl.conf` as global/system configuration,
and it may also load `~/.config/youtube-dl/config` as user configuration.
So, the `system-files` interface is required for the snap to load system file
under `/etc/` directory, and `personal-files` interface is required for the
snap to load hidden file under user's home directory.

Signed-off-by: Tao Wang <twang2218@gmail.com>

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [ ] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Current `youtube-dl` snap cannot load `~/.config/youtube-dl/config` and `/etc/youtube-dl.conf` as user and system configurations, the reason is because the snap is lacking `personal-files` and `system-files` interfaces, which are added in this PR.

To test the issue, if we create the file `~/.config/youtube-dl/config` or `/etc/youtube-dl.conf` with following content:

```
-f 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/mp4'
-o '%(title)20s-%(id)s.%(ext)s'
```

then run the command `youtube-dl -v`, the output will show empty system and user configuration.

```
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: ['-v']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2021.06.06
[debug] Python version 3.6.9 (CPython) - Linux-5.11.0-31-generic-x86_64-with-Ubuntu-21.04-hirsute
[debug] exe versions: ffmpeg 3.4.8, ffprobe 3.4.8
[debug] Proxy map: {}
Usage: youtube-dl [OPTIONS] URL [URL...]

youtube-dl: error: You must provide at least one URL.
Type youtube-dl --help to see a list of all options.
```

With this PR, the snap is capable to load the config files if the interface/plugs are connected.

To connect the plugs after the installation of the snap, the following commands should be executed:

```shell
snap connect youtube-dl:dot-config-youtube-dl
snap connect youtube-dl:config-youtube-dl
```

Then the result can be tested via command `youtube-dl -v`:

```
[debug] System config: ['-o', '%(title)s.%(ext)s']
[debug] User config: ['-f', 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/mp4', '-o', '%(title)20s-%(id)s.%(ext)s']
[debug] Custom config: []
[debug] Command-line args: ['-v']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2021.06.06
[debug] Python version 3.6.9 (CPython) - Linux-5.11.0-31-generic-x86_64-with-Ubuntu-21.04-hirsute
[debug] exe versions: ffmpeg 3.4.8, ffprobe 3.4.8
[debug] Proxy map: {}
Usage: youtube-dl [OPTIONS] URL [URL...]
```

The above result show both system `/etc/youtube-dl.conf` and user's `~/.config/youtube-dl/config` have been loaded by `youtube-dl`.

#### References

- [Snapcraft doc - personal-files](https://snapcraft.io/docs/personal-files-interface)

> `$HOME` is set to `$SNAP_USER_DATA` for non-daemon commands.
> ...
> The `personal-files` interface is typically used to provide read-only access to top-level **hidden** data directories within a **user’s real home** directory

- [Snapcraft doc - system-files](https://snapcraft.io/docs/system-files-interface)

> The `system-files` interface enables a snap to access specific system files and directories (such as files in /etc).

- [Snapcraft doc - Permission Request](https://snapcraft.io/docs/permission-requests)

> `Auto-connect` indicates that the interface will be connected by default when the snap is first installed, requiring no further user action. If `Auto-connect=no`, an interface can still be automatically connected if the snap developer has **requested**, and been granted, explicit permission. See [Permission requests](https://snapcraft.io/docs/permission-requests) for details.

- [Snapcraft doc - Environment Variables](https://snapcraft.io/docs/environment-variables)

> #### SNAP_REAL_HOME
> The vanilla `HOME` environment variable before snapd-induced remapping, refer [Any way to acquire the originally set `HOME` environment variable? - snapcraft - snapcraft.io](https://forum.snapcraft.io/t/any-way-to-acquire-the-originally-set-home-environment-variable/19475?_ga=2.112449924.1813163060.1631499670-954377516.1629077994) for more info.

